### PR TITLE
Dockerfile for dockerizing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /ReFlow
+WORKDIR /ReFlow
+ADD requirements.txt /ReFlow/
+RUN pip install -r requirements.txt
+ADD . /ReFlow/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM python:2.7
 ENV PYTHONUNBUFFERED 1
+RUN git clone https://github.com/whitews/FlowIO.git /flowio
+WORKDIR /flowio
+RUN python setup.py install
 RUN mkdir /ReFlow
 WORKDIR /ReFlow
 ADD requirements.txt /ReFlow/
 RUN pip install -r requirements.txt
 ADD . /ReFlow/
+EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.7
+django==1.7
 django-guardian==1.2.4
 django-filter==0.7
 djangorestframework==2.3.13


### PR DESCRIPTION
Quick and dirty, just for development:

To Build:
`docker build -t reflow .`
To get into the container:

```
docker run -v `pwd`:/ReFlow -it reflow bash
```

To run django

```
docker run -v `pwd`:/ReFlow -P reflow
docker ps
```

Gather the port from `docker ps`, and the ip from `boot2docker ip`. Combine them, e.g. http://192.168.59.103:32769
